### PR TITLE
fix(drag): style assignment for dragged element on IE

### DIFF
--- a/src/draggable.directive.ts
+++ b/src/draggable.directive.ts
@@ -223,12 +223,12 @@ export class DraggableDirective implements OnInit, OnChanges, OnDestroy {
               this.dragEnd.next({ x, y });
             });
             currentDrag.complete();
-            this.setCssTransform(null);
+            this.setCssTransform('');
             if (this.ghostDragEnabled) {
               this.renderer.setStyle(
                 this.element.nativeElement,
                 'pointerEvents',
-                null
+                ''
               );
             }
           });


### PR DESCRIPTION
Apparently setting a style property to null doesn't actually remove it in IE11.
Tested with the latest versions of IE, Chrome and Firefox.

Apparently known, but still occurring:
https://github.com/angular/angular/issues/7916

This also fixes the similar issue with angular-calendar, allowing it to be used normally with draggable events in IE.

Fixes https://github.com/mattlewis92/angular-draggable-droppable/issues/29