### PR TITLE
Update Draggable directive for grid.

### DIFF
--- a/src/draggable.directive.ts
+++ b/src/draggable.directive.ts
@@ -180,13 +180,13 @@ export class DraggableDirective implements OnInit, OnChanges, OnDestroy {
           map((moveData: Coordinates) => {
             if (this.dragSnapGrid.x) {
               moveData.x =
-                Math.floor(moveData.x / this.dragSnapGrid.x) *
+                Math.round(moveData.x / this.dragSnapGrid.x) *
                 this.dragSnapGrid.x;
             }
 
             if (this.dragSnapGrid.y) {
               moveData.y =
-                Math.floor(moveData.y / this.dragSnapGrid.y) *
+                Math.round(moveData.y / this.dragSnapGrid.y) *
                 this.dragSnapGrid.y;
             }
 

--- a/test/draggable.directive.spec.ts
+++ b/test/draggable.directive.spec.ts
@@ -192,7 +192,7 @@ describe('draggable directive', () => {
       clientY: 18
     });
     expect(fixture.componentInstance.dragging).to.have.been.calledWith({
-      x: 0,
+      x: 10,
       y: 8
     });
     triggerDomEvent('mousemove', draggableElement, {
@@ -235,7 +235,7 @@ describe('draggable directive', () => {
     });
     expect(fixture.componentInstance.dragging).to.have.been.calledWith({
       x: 8,
-      y: 0
+      y: 10
     });
     triggerDomEvent('mousemove', draggableElement, {
       clientX: 20,
@@ -353,7 +353,7 @@ describe('draggable directive', () => {
       y: 10
     });
     triggerDomEvent('mousemove', draggableElement, {
-      clientX: 18,
+      clientX: 14,
       clientY: 18
     });
     expect(fixture.componentInstance.dragging).to.have.been.calledOnce;


### PR DESCRIPTION
Grid drag is now centerd instead of staring in the starting drag locations causing the left drag to be a lot faster than the right drag.