### PR TITLE
feat: add droppable restrictByEventTarget option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [4.6.0](https://github.com/mattlewis92/angular-draggable-droppable/compare/v4.5.6...v4.6.0) (2020-12-10)
+
+
+### Features
+
+* add droppable restrictByEventTarget option ([aa9b0cf](https://github.com/mattlewis92/angular-draggable-droppable/commit/aa9b0cf861061f84aa11f8822b955340f5681f4e))
+
 ### [4.5.6](https://github.com/mattlewis92/angular-draggable-droppable/compare/v4.5.5...v4.5.6) (2020-10-22)
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-draggable-droppable",
-  "version": "4.5.6",
+  "version": "4.6.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-draggable-droppable",
-  "version": "4.5.6",
+  "version": "4.6.0",
   "description": "Drag and drop for angular 6.0+",
   "scripts": {
     "start": "concurrently --raw \"ng serve --open\" \"npm run test:watch\"",

--- a/projects/angular-draggable-droppable/src/lib/draggable-helper.provider.ts
+++ b/projects/angular-draggable-droppable/src/lib/draggable-helper.provider.ts
@@ -5,6 +5,7 @@ export interface CurrentDragData {
   clientX: number;
   clientY: number;
   dropData: any;
+  target: EventTarget;
 }
 
 @Injectable({

--- a/projects/angular-draggable-droppable/src/lib/draggable.directive.ts
+++ b/projects/angular-draggable-droppable/src/lib/draggable.directive.ts
@@ -316,6 +316,7 @@ export class DraggableDirective implements OnInit, OnChanges, OnDestroy {
               clientY: pointerMoveEvent.clientY,
               scrollLeft: scroll.left,
               scrollTop: scroll.top,
+              target: pointerMoveEvent.event.target,
             };
           }),
           map((moveData) => {
@@ -518,7 +519,16 @@ export class DraggableDirective implements OnInit, OnChanges, OnDestroy {
         map(([previous, next]) => next)
       )
       .subscribe(
-        ({ x, y, currentDrag$, clientX, clientY, transformX, transformY }) => {
+        ({
+          x,
+          y,
+          currentDrag$,
+          clientX,
+          clientY,
+          transformX,
+          transformY,
+          target,
+        }) => {
           this.zone.run(() => {
             this.dragging.next({ x, y });
           });
@@ -538,6 +548,7 @@ export class DraggableDirective implements OnInit, OnChanges, OnDestroy {
             clientX,
             clientY,
             dropData: this.dropData,
+            target,
           });
         }
       );

--- a/projects/angular-draggable-droppable/src/lib/droppable.directive.spec.ts
+++ b/projects/angular-draggable-droppable/src/lib/droppable.directive.spec.ts
@@ -29,6 +29,7 @@ describe('droppable directive', () => {
         (drop)="drop($event)"
         [dragOverClass]="dragOverClass"
         [dragActiveClass]="dragActiveClass"
+        [restrictByEventTarget]="restrictByEventTarget"
       >
         Drop here
       </div>
@@ -69,6 +70,7 @@ describe('droppable directive', () => {
     };
     dragOverClass: string;
     dragActiveClass: string;
+    restrictByEventTarget: boolean;
   }
 
   @Component({
@@ -410,5 +412,55 @@ describe('droppable directive', () => {
       button: 0,
     });
     expect(scrollFixture.componentInstance.drop).not.to.have.been.called;
+  });
+
+  it('should fire drop events when the event target is within the droppable', () => {
+    const draggableElement =
+      fixture.componentInstance.draggableElement.nativeElement;
+    const droppableElement =
+      fixture.componentInstance.droppableElement.nativeElement;
+    const elementInsideDroppableArea = document.createElement('div');
+    droppableElement.appendChild(elementInsideDroppableArea);
+    fixture.componentInstance.restrictByEventTarget = true;
+    fixture.detectChanges();
+    triggerDomEvent('mousedown', draggableElement, {
+      clientX: 5,
+      clientY: 10,
+      button: 0,
+    });
+    triggerDomEvent('mousemove', elementInsideDroppableArea, {
+      clientX: 5,
+      clientY: 120,
+    });
+    triggerDomEvent('mouseup', draggableElement, {
+      clientX: 5,
+      clientY: 120,
+      button: 0,
+    });
+    expect(fixture.componentInstance.drop).to.have.been.called;
+  });
+
+  it('should not fire drop events when the event target is not within the droppable', () => {
+    const draggableElement =
+      fixture.componentInstance.draggableElement.nativeElement;
+    const elementOutsideDroppableArea = document.createElement('div');
+    document.body.appendChild(elementOutsideDroppableArea);
+    fixture.componentInstance.restrictByEventTarget = true;
+    fixture.detectChanges();
+    triggerDomEvent('mousedown', draggableElement, {
+      clientX: 5,
+      clientY: 10,
+      button: 0,
+    });
+    triggerDomEvent('mousemove', elementOutsideDroppableArea, {
+      clientX: 5,
+      clientY: 120,
+    });
+    triggerDomEvent('mouseup', draggableElement, {
+      clientX: 5,
+      clientY: 120,
+      button: 0,
+    });
+    expect(fixture.componentInstance.drop).not.to.have.been.called;
   });
 });

--- a/src/demo/demo.component.css
+++ b/src/demo/demo.component.css
@@ -1,3 +1,7 @@
+:host {
+  display: flex;
+}
+
 [mwlDraggable] {
   background-color: red;
   width: 200px;
@@ -19,6 +23,10 @@
   left: 100px;
 }
 
+.restrictByEventTarget {
+  left: 150px;
+}
+
 [mwlDraggable],
 [mwlDroppable] {
   color: white;
@@ -35,4 +43,24 @@
 
 .drag-active {
   z-index: 3;
+}
+
+.floating-toolbar {
+  position: absolute;
+  top: 140px;
+  z-index: 2;
+  width: 250px;
+  height: 75px;
+  background: yellow;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.floating-toolbar-1 {
+  left: 600px;
+}
+
+.floating-toolbar-2 {
+  left: 1050px;
 }

--- a/src/demo/demo.component.html
+++ b/src/demo/demo.component.html
@@ -21,3 +21,22 @@
     >Item dropped here with data: "{{ droppedData }}"!</span
   >
 </div>
+<div
+  mwlDroppable
+  (drop)="onDrop2($event)"
+  dragOverClass="drop-over-active"
+  [restrictByEventTarget]="true"
+  class="restrictByEventTarget"
+>
+  <span [hidden]="droppedData2">Drop here</span>
+  <span [hidden]="!droppedData2"
+    >Item dropped here with data: "{{ droppedData2 }}"!</span
+  >
+</div>
+
+<div class="floating-toolbar floating-toolbar-1">
+  Floating toolbar, drop here too!
+</div>
+<div class="floating-toolbar floating-toolbar-2">
+  Floating toolbar, can't drop here!
+</div>

--- a/src/demo/demo.component.ts
+++ b/src/demo/demo.component.ts
@@ -8,11 +8,19 @@ import { DropEvent } from 'angular-draggable-droppable';
 })
 export class DemoComponent {
   droppedData: string = '';
+  droppedData2: string = '';
 
   onDrop({ dropData }: DropEvent<string>): void {
     this.droppedData = dropData;
     setTimeout(() => {
       this.droppedData = '';
+    }, 2000);
+  }
+
+  onDrop2({ dropData }: DropEvent<string>): void {
+    this.droppedData2 = dropData;
+    setTimeout(() => {
+      this.droppedData2 = '';
     }, 2000);
   }
 }


### PR DESCRIPTION
Add a new input to `DroppableDirective` that allows you to restrict the drop location by event target. When `restrictByEventTarget` is enabled you can only drop onto the `[mwlDroppable]` element or any of its descendants, not elements that are outside but overlay `[mwlDroppable]`.

![demo](https://user-images.githubusercontent.com/540445/101687191-08932880-3a62-11eb-909b-20172690dd0d.gif)
