### PR TITLE
feat: add validateDrop to mwlDroppable directive

### DIFF
--- a/projects/angular-draggable-droppable/src/lib/draggable-helper.provider.ts
+++ b/projects/angular-draggable-droppable/src/lib/draggable-helper.provider.ts
@@ -5,6 +5,7 @@ export interface CurrentDragData {
   clientX: number;
   clientY: number;
   dropData: any;
+  target: EventTarget;
 }
 
 @Injectable({

--- a/projects/angular-draggable-droppable/src/lib/draggable.directive.ts
+++ b/projects/angular-draggable-droppable/src/lib/draggable.directive.ts
@@ -316,6 +316,7 @@ export class DraggableDirective implements OnInit, OnChanges, OnDestroy {
               clientY: pointerMoveEvent.clientY,
               scrollLeft: scroll.left,
               scrollTop: scroll.top,
+              target: pointerMoveEvent.event.target,
             };
           }),
           map((moveData) => {
@@ -518,7 +519,16 @@ export class DraggableDirective implements OnInit, OnChanges, OnDestroy {
         map(([previous, next]) => next)
       )
       .subscribe(
-        ({ x, y, currentDrag$, clientX, clientY, transformX, transformY }) => {
+        ({
+          x,
+          y,
+          currentDrag$,
+          clientX,
+          clientY,
+          transformX,
+          transformY,
+          target,
+        }) => {
           this.zone.run(() => {
             this.dragging.next({ x, y });
           });
@@ -538,6 +548,7 @@ export class DraggableDirective implements OnInit, OnChanges, OnDestroy {
             clientX,
             clientY,
             dropData: this.dropData,
+            target,
           });
         }
       );

--- a/projects/angular-draggable-droppable/src/lib/droppable.directive.spec.ts
+++ b/projects/angular-draggable-droppable/src/lib/droppable.directive.spec.ts
@@ -29,6 +29,7 @@ describe('droppable directive', () => {
         (drop)="drop($event)"
         [dragOverClass]="dragOverClass"
         [dragActiveClass]="dragActiveClass"
+        [restrictByEventTarget]="restrictByEventTarget"
       >
         Drop here
       </div>
@@ -69,6 +70,7 @@ describe('droppable directive', () => {
     };
     dragOverClass: string;
     dragActiveClass: string;
+    restrictByEventTarget: boolean;
   }
 
   @Component({
@@ -410,5 +412,55 @@ describe('droppable directive', () => {
       button: 0,
     });
     expect(scrollFixture.componentInstance.drop).not.to.have.been.called;
+  });
+
+  it('should fire drop events when the event target is within the droppable', () => {
+    const draggableElement =
+      fixture.componentInstance.draggableElement.nativeElement;
+    const droppableElement =
+      fixture.componentInstance.droppableElement.nativeElement;
+    const elementInsideDroppableArea = document.createElement('div');
+    droppableElement.appendChild(elementInsideDroppableArea);
+    fixture.componentInstance.restrictByEventTarget = true;
+    fixture.detectChanges();
+    triggerDomEvent('mousedown', draggableElement, {
+      clientX: 5,
+      clientY: 10,
+      button: 0,
+    });
+    triggerDomEvent('mousemove', elementInsideDroppableArea, {
+      clientX: 5,
+      clientY: 120,
+    });
+    triggerDomEvent('mouseup', draggableElement, {
+      clientX: 5,
+      clientY: 120,
+      button: 0,
+    });
+    expect(fixture.componentInstance.drop).to.have.been.called;
+  });
+
+  it('should not fire drop events when the event target is not within the droppable', () => {
+    const draggableElement =
+      fixture.componentInstance.draggableElement.nativeElement;
+    const elementOutsideDroppableArea = document.createElement('div');
+    document.body.appendChild(elementOutsideDroppableArea);
+    fixture.componentInstance.restrictByEventTarget = true;
+    fixture.detectChanges();
+    triggerDomEvent('mousedown', draggableElement, {
+      clientX: 5,
+      clientY: 10,
+      button: 0,
+    });
+    triggerDomEvent('mousemove', elementOutsideDroppableArea, {
+      clientX: 5,
+      clientY: 120,
+    });
+    triggerDomEvent('mouseup', draggableElement, {
+      clientX: 5,
+      clientY: 120,
+      button: 0,
+    });
+    expect(fixture.componentInstance.drop).not.to.have.been.called;
   });
 });

--- a/projects/angular-draggable-droppable/src/lib/droppable.directive.spec.ts
+++ b/projects/angular-draggable-droppable/src/lib/droppable.directive.spec.ts
@@ -5,7 +5,7 @@ import * as sinon from 'sinon';
 import { triggerDomEvent } from '../test-utils';
 import { DragAndDropModule } from 'angular-draggable-droppable';
 import { DraggableDirective } from './draggable.directive';
-import { DroppableDirective } from './droppable.directive';
+import { DroppableDirective, ValidateDrop } from './droppable.directive';
 import { DraggableScrollContainerDirective } from './draggable-scroll-container.directive';
 import { By } from '@angular/platform-browser';
 
@@ -29,7 +29,7 @@ describe('droppable directive', () => {
         (drop)="drop($event)"
         [dragOverClass]="dragOverClass"
         [dragActiveClass]="dragActiveClass"
-        [restrictByEventTarget]="restrictByEventTarget"
+        [validateDrop]="validateDrop"
       >
         Drop here
       </div>
@@ -70,7 +70,7 @@ describe('droppable directive', () => {
     };
     dragOverClass: string;
     dragActiveClass: string;
-    restrictByEventTarget: boolean;
+    validateDrop: ValidateDrop;
   }
 
   @Component({
@@ -414,14 +414,14 @@ describe('droppable directive', () => {
     expect(scrollFixture.componentInstance.drop).not.to.have.been.called;
   });
 
-  it('should fire drop events when the event target is within the droppable', () => {
+  it('should fire drop events when validateDrop returns true', () => {
     const draggableElement =
       fixture.componentInstance.draggableElement.nativeElement;
     const droppableElement =
       fixture.componentInstance.droppableElement.nativeElement;
     const elementInsideDroppableArea = document.createElement('div');
     droppableElement.appendChild(elementInsideDroppableArea);
-    fixture.componentInstance.restrictByEventTarget = true;
+    fixture.componentInstance.validateDrop = () => true;
     fixture.detectChanges();
     triggerDomEvent('mousedown', draggableElement, {
       clientX: 5,
@@ -440,12 +440,14 @@ describe('droppable directive', () => {
     expect(fixture.componentInstance.drop).to.have.been.called;
   });
 
-  it('should not fire drop events when the event target is not within the droppable', () => {
+  it('should not fire drop events when validateDrop returns false', () => {
     const draggableElement =
       fixture.componentInstance.draggableElement.nativeElement;
+    const droppableElement =
+      fixture.componentInstance.droppableElement.nativeElement;
     const elementOutsideDroppableArea = document.createElement('div');
     document.body.appendChild(elementOutsideDroppableArea);
-    fixture.componentInstance.restrictByEventTarget = true;
+    fixture.componentInstance.validateDrop = () => false;
     fixture.detectChanges();
     triggerDomEvent('mousedown', draggableElement, {
       clientX: 5,

--- a/projects/angular-draggable-droppable/src/lib/droppable.directive.ts
+++ b/projects/angular-draggable-droppable/src/lib/droppable.directive.ts
@@ -35,11 +35,11 @@ export interface DropEvent<T = any> {
 
 export interface ValidateDropParams {
   /**
-   * CientX value of the mouse location where the drop occurred
+   * ClientX value of the mouse location where the drop occurred
    */
   clientX: number;
   /**
-   * CientY value of the mouse location where the drop occurred
+   * ClientY value of the mouse location where the drop occurred
    */
   clientY: number;
   /**

--- a/projects/angular-draggable-droppable/src/public_api.ts
+++ b/projects/angular-draggable-droppable/src/public_api.ts
@@ -3,7 +3,11 @@
  */
 
 export * from './lib/drag-and-drop.module';
-export { DropEvent } from './lib/droppable.directive';
+export {
+  DropEvent,
+  ValidateDrop,
+  ValidateDropParams,
+} from './lib/droppable.directive';
 export {
   DragPointerDownEvent,
   DragStartEvent,

--- a/src/demo/demo.component.css
+++ b/src/demo/demo.component.css
@@ -23,7 +23,7 @@
   left: 100px;
 }
 
-.restrictByEventTarget {
+.validate-drop {
   left: 150px;
 }
 

--- a/src/demo/demo.component.css
+++ b/src/demo/demo.component.css
@@ -1,3 +1,7 @@
+:host {
+  display: flex;
+}
+
 [mwlDraggable] {
   background-color: red;
   width: 200px;
@@ -19,6 +23,10 @@
   left: 100px;
 }
 
+.restrictByEventTarget {
+  left: 150px;
+}
+
 [mwlDraggable],
 [mwlDroppable] {
   color: white;
@@ -35,4 +43,24 @@
 
 .drag-active {
   z-index: 3;
+}
+
+.floating-toolbar {
+  position: absolute;
+  top: 140px;
+  z-index: 2;
+  width: 250px;
+  height: 75px;
+  background: yellow;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.floating-toolbar-1 {
+  left: 600px;
+}
+
+.floating-toolbar-2 {
+  left: 1050px;
 }

--- a/src/demo/demo.component.html
+++ b/src/demo/demo.component.html
@@ -21,3 +21,22 @@
     >Item dropped here with data: "{{ droppedData }}"!</span
   >
 </div>
+<div
+  mwlDroppable
+  (drop)="onDrop2($event)"
+  dragOverClass="drop-over-active"
+  [restrictByEventTarget]="true"
+  class="restrictByEventTarget"
+>
+  <span [hidden]="droppedData2">Drop here</span>
+  <span [hidden]="!droppedData2"
+    >Item dropped here with data: "{{ droppedData2 }}"!</span
+  >
+</div>
+
+<div class="floating-toolbar floating-toolbar-1">
+  Floating toolbar, drop here too!
+</div>
+<div class="floating-toolbar floating-toolbar-2">
+  Floating toolbar, can't drop here!
+</div>

--- a/src/demo/demo.component.html
+++ b/src/demo/demo.component.html
@@ -25,8 +25,8 @@
   mwlDroppable
   (drop)="onDrop2($event)"
   dragOverClass="drop-over-active"
-  [restrictByEventTarget]="true"
-  class="restrictByEventTarget"
+  [validateDrop]="validateDrop"
+  class="validate-drop"
 >
   <span [hidden]="droppedData2">Drop here</span>
   <span [hidden]="!droppedData2"

--- a/src/demo/demo.component.ts
+++ b/src/demo/demo.component.ts
@@ -1,5 +1,9 @@
-import { Component } from '@angular/core';
+import { Component, ElementRef, ViewChild } from '@angular/core';
 import { DropEvent } from 'angular-draggable-droppable';
+import {
+  DroppableDirective,
+  ValidateDrop,
+} from 'projects/angular-draggable-droppable/src/lib/droppable.directive';
 
 @Component({
   selector: 'mwl-demo-app',
@@ -9,6 +13,9 @@ import { DropEvent } from 'angular-draggable-droppable';
 export class DemoComponent {
   droppedData: string = '';
   droppedData2: string = '';
+
+  @ViewChild(DroppableDirective, { read: ElementRef })
+  droppableElement: ElementRef;
 
   onDrop({ dropData }: DropEvent<string>): void {
     this.droppedData = dropData;
@@ -23,4 +30,7 @@ export class DemoComponent {
       this.droppedData2 = '';
     }, 2000);
   }
+
+  validateDrop: ValidateDrop = ({ target }) =>
+    this.droppableElement.nativeElement.contains(target as Node);
 }

--- a/src/demo/demo.component.ts
+++ b/src/demo/demo.component.ts
@@ -8,11 +8,19 @@ import { DropEvent } from 'angular-draggable-droppable';
 })
 export class DemoComponent {
   droppedData: string = '';
+  droppedData2: string = '';
 
   onDrop({ dropData }: DropEvent<string>): void {
     this.droppedData = dropData;
     setTimeout(() => {
       this.droppedData = '';
+    }, 2000);
+  }
+
+  onDrop2({ dropData }: DropEvent<string>): void {
+    this.droppedData2 = dropData;
+    setTimeout(() => {
+      this.droppedData2 = '';
     }, 2000);
   }
 }


### PR DESCRIPTION
Add a new input to `DroppableDirective` that allows you to restrict the drop with a new `validateDrop` function input. When `validateDrop` is defined it will allow/disallow the drop event being fired. The event target fromthe mouse move event has also been piped through from `DraggableDirective` to be included in `ValidateDropParams`

![demo](https://user-images.githubusercontent.com/540445/101687191-08932880-3a62-11eb-909b-20172690dd0d.gif)
