### PR TITLE
perf: do not run change detection if there are no event listeners

### DIFF
--- a/projects/angular-draggable-droppable/src/lib/draggable.directive.ts
+++ b/projects/angular-draggable-droppable/src/lib/draggable.directive.ts
@@ -291,9 +291,11 @@ export class DraggableDirective implements OnInit, OnChanges, OnDestroy {
         const currentDrag$ = new Subject<CurrentDragData>();
         const cancelDrag$ = new ReplaySubject<void>();
 
-        this.zone.run(() => {
-          this.dragPointerDown.next({ x: 0, y: 0 });
-        });
+        if (this.dragPointerDown.observers.length > 0) {
+          this.zone.run(() => {
+            this.dragPointerDown.next({ x: 0, y: 0 });
+          });
+        }
 
         const dragComplete$ = merge(
           this.pointerUp$,
@@ -370,9 +372,11 @@ export class DraggableDirective implements OnInit, OnChanges, OnDestroy {
         const dragEnded$ = pointerMove.pipe(takeLast(1), share());
 
         dragStarted$.subscribe(({ clientX, clientY, x, y }) => {
-          this.zone.run(() => {
-            this.dragStart.next({ cancelDrag$ });
-          });
+          if (this.dragStart.observers.length > 0) {
+            this.zone.run(() => {
+              this.dragStart.next({ cancelDrag$ });
+            });
+          }
 
           this.scroller = autoScroll(
             [
@@ -442,13 +446,15 @@ export class DraggableDirective implements OnInit, OnChanges, OnDestroy {
               });
             }
 
-            this.zone.run(() => {
-              this.ghostElementCreated.emit({
-                clientX: clientX - x,
-                clientY: clientY - y,
-                element: clone,
+            if (this.ghostElementCreated.observers.length > 0) {
+              this.zone.run(() => {
+                this.ghostElementCreated.emit({
+                  clientX: clientX - x,
+                  clientY: clientY - y,
+                  element: clone,
+                });
               });
-            });
+            }
 
             dragEnded$.subscribe(() => {
               clone.parentElement!.removeChild(clone);
@@ -481,9 +487,11 @@ export class DraggableDirective implements OnInit, OnChanges, OnDestroy {
           )
           .subscribe(({ x, y, dragCancelled }) => {
             this.scroller.destroy();
-            this.zone.run(() => {
-              this.dragEnd.next({ x, y, dragCancelled });
-            });
+            if (this.dragEnd.observers.length > 0) {
+              this.zone.run(() => {
+                this.dragEnd.next({ x, y, dragCancelled });
+              });
+            }
             removeClass(this.renderer, this.element, this.dragActiveClass);
             currentDrag$.complete();
           });
@@ -528,9 +536,11 @@ export class DraggableDirective implements OnInit, OnChanges, OnDestroy {
           transformY,
           target,
         }) => {
-          this.zone.run(() => {
-            this.dragging.next({ x, y });
-          });
+          if (this.dragging.observers.length > 0) {
+            this.zone.run(() => {
+              this.dragging.next({ x, y });
+            });
+          }
           requestAnimationFrame(() => {
             if (this.ghostElement) {
               const transform = `translate3d(${transformX}px, ${transformY}px, 0px)`;

--- a/projects/angular-draggable-droppable/src/lib/droppable.directive.ts
+++ b/projects/angular-draggable-droppable/src/lib/droppable.directive.ts
@@ -169,19 +169,23 @@ export class DroppableDirective implements OnInit, OnDestroy {
           .subscribe(() => {
             dragOverActive = true;
             addClass(this.renderer, this.element, this.dragOverClass);
-            this.zone.run(() => {
-              this.dragEnter.next({
-                dropData: currentDragDropData,
+            if (this.dragEnter.observers.length > 0) {
+              this.zone.run(() => {
+                this.dragEnter.next({
+                  dropData: currentDragDropData,
+                });
               });
-            });
+            }
           });
 
         overlaps$.pipe(filter((overlapsNow) => overlapsNow)).subscribe(() => {
-          this.zone.run(() => {
-            this.dragOver.next({
-              dropData: currentDragDropData,
+          if (this.dragOver.observers.length > 0) {
+            this.zone.run(() => {
+              this.dragOver.next({
+                dropData: currentDragDropData,
+              });
             });
-          });
+          }
         });
 
         overlapsChanged$
@@ -192,11 +196,13 @@ export class DroppableDirective implements OnInit, OnDestroy {
           .subscribe(() => {
             dragOverActive = false;
             removeClass(this.renderer, this.element, this.dragOverClass);
-            this.zone.run(() => {
-              this.dragLeave.next({
-                dropData: currentDragDropData,
+            if (this.dragLeave.observers.length > 0) {
+              this.zone.run(() => {
+                this.dragLeave.next({
+                  dropData: currentDragDropData,
+                });
               });
-            });
+            }
           });
 
         drag$.subscribe({
@@ -205,11 +211,13 @@ export class DroppableDirective implements OnInit, OnDestroy {
             removeClass(this.renderer, this.element, this.dragActiveClass);
             if (dragOverActive) {
               removeClass(this.renderer, this.element, this.dragOverClass);
-              this.zone.run(() => {
-                this.drop.next({
-                  dropData: currentDragDropData,
+              if (this.drop.observers.length > 0) {
+                this.zone.run(() => {
+                  this.drop.next({
+                    dropData: currentDragDropData,
+                  });
                 });
-              });
+              }
             }
           },
         });


### PR DESCRIPTION
Hey Matt. No functional changes in this PR, just added checks if emitters are observed before running `tick()`.